### PR TITLE
Rule for jest-expect-saga

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+*.swp
+
+pids
+logs
+results
+tmp
+
+# Build
+public/css/main.css
+
+# Coverage reports
+coverage
+
+# API keys and secrets
+.env
+
+# Dependency directory
+node_modules
+bower_components
+
+# Editors
+.idea
+*.iml
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Ignore built ts files
+dist/**/*
+
+# ignore yarn.lock
+yarn.lock

--- a/lib/rules/jest-return-expect-saga.js
+++ b/lib/rules/jest-return-expect-saga.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Name all selectors with a 'get' prefix
+ * @author drop
+ */
+'use strict'
+const errorMessage = 'expectSagas in `it` blocks should be returned'
+const isExplicitReturn = node => node.parent.type === 'ReturnStatement'
+const isArrowFunctionWithImplicitReturn = node =>
+  node.parent.type === 'ArrowFunctionExpression' &&
+  node.parent.expression === true
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+const ruleModule = {
+  meta: {
+    docs: {
+      description: 'Ensure expectSagas are returned',
+      category: 'jest',
+      recommended: false,
+    },
+    fixable: undefined,
+    schema: [],
+  },
+  create: context => ({
+    CallExpression: node => {
+      if (
+        node.callee.type === 'Identifier' &&
+        node.callee.name === 'expectSaga'
+      ) {
+        if (
+          !(isExplicitReturn(node) || isArrowFunctionWithImplicitReturn(node))
+        )
+          context.report({
+            node,
+            message: errorMessage,
+          })
+      }
+      return null
+    },
+  }),
+}
+module.exports = ruleModule

--- a/lib/rules/jest-return-expect-saga.js
+++ b/lib/rules/jest-return-expect-saga.js
@@ -8,6 +8,22 @@ const isExplicitReturn = node => node.parent.type === 'ReturnStatement'
 const isArrowFunctionWithImplicitReturn = node =>
   node.parent.type === 'ArrowFunctionExpression' &&
   node.parent.expression === true
+
+const getRootMemberExpression = node => {
+  if (
+    !node.parent ||
+    (node.parent.type !== 'MemberExpression' &&
+      node.parent.type !== 'CallExpression')
+  ) {
+    return node
+  }
+  if (
+    (node.parent && node.parent.type === 'MemberExpression') ||
+    node.parent.type === 'CallExpression'
+  )
+    return getRootMemberExpression(node.parent)
+  return node
+}
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -27,6 +43,13 @@ const ruleModule = {
         node.callee.type === 'Identifier' &&
         node.callee.name === 'expectSaga'
       ) {
+        if (
+          node.type === 'CallExpression' &&
+          node.parent.type === 'MemberExpression'
+        ) {
+          node = getRootMemberExpression(node)
+        }
+
         if (
           !(isExplicitReturn(node) || isArrowFunctionWithImplicitReturn(node))
         )

--- a/lib/rules/jest-return-expect-saga.js
+++ b/lib/rules/jest-return-expect-saga.js
@@ -41,7 +41,8 @@ const ruleModule = {
     CallExpression: node => {
       if (
         node.callee.type === 'Identifier' &&
-        node.callee.name === 'expectSaga'
+        (node.callee.name === 'expectSaga' ||
+          node.callee.name === 'generateExpectSaga')
       ) {
         if (
           node.type === 'CallExpression' &&

--- a/tests/lib/rules/jest-return-expect-saga.js
+++ b/tests/lib/rules/jest-return-expect-saga.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Require explicit booleans in JSX conditional rendering using &&
+ * @author drop
+ */
+'use strict';
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+const rule = require('../../../lib/rules/jest-return-expect-saga');
+// eslint-disable-next-line
+const { RuleTester } = require('eslint');
+RuleTester.setDefaultConfig({
+    parserOptions: {
+        ecmaVersion: 6,
+        sourceType: 'module',
+        ecmaFeatures: {
+            modules: true,
+            jsx: true,
+        },
+    },
+});
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+const ruleTester = new RuleTester();
+ruleTester.run('jest-return-expect-saga', rule, {
+    valid: [
+        {
+            code: `
+        describe(() => {
+            it(() => {
+                return expectSaga()
+            })
+        })
+        `,
+            filename: 'test.js',
+        },
+        {
+            code: `
+      describe(() => {
+        it(() => expectSaga())
+      })
+        `,
+            filename: 'test.js',
+        },
+    ],
+    invalid: [
+        {
+            code: `
+      describe(() => {
+          it(() => {
+              expectSaga()
+          })
+      })
+      `,
+            filename: 'test.js',
+            errors: [
+                {
+                    message: 'expectSagas in `it` blocks should be returned',
+                },
+            ],
+        },
+    ],
+});

--- a/tests/lib/rules/jest-return-expect-saga.js
+++ b/tests/lib/rules/jest-return-expect-saga.js
@@ -2,63 +2,97 @@
  * @fileoverview Require explicit booleans in JSX conditional rendering using &&
  * @author drop
  */
-'use strict';
+'use strict'
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
-const rule = require('../../../lib/rules/jest-return-expect-saga');
+const rule = require('../../../lib/rules/jest-return-expect-saga')
 // eslint-disable-next-line
-const { RuleTester } = require('eslint');
+const { RuleTester } = require('eslint')
 RuleTester.setDefaultConfig({
-    parserOptions: {
-        ecmaVersion: 6,
-        sourceType: 'module',
-        ecmaFeatures: {
-            modules: true,
-            jsx: true,
-        },
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    ecmaFeatures: {
+      modules: true,
+      jsx: true,
     },
-});
+  },
+})
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester()
 ruleTester.run('jest-return-expect-saga', rule, {
-    valid: [
-        {
-            code: `
-        describe(() => {
-            it(() => {
-                return expectSaga()
+  valid: [
+    {
+      code: `
+            describe(() => {
+                it(() => {
+                    return expectSaga()
+                })
             })
-        })
         `,
-            filename: 'test.js',
-        },
-        {
-            code: `
+      filename: 'test.js',
+    },
+    {
+      code: `
       describe(() => {
         it(() => expectSaga())
       })
         `,
-            filename: 'test.js',
-        },
-    ],
-    invalid: [
+      filename: 'test.js',
+    },
+    {
+      code: `
+        const generateExpectSaga = () => expectSaga()
+          `,
+      filename: 'test.js',
+    },
+    {
+      code: `
+          import { expectSaga } from 'some-library'
+            `,
+      filename: 'test.js',
+    },
+    {
+      code: `
+      it('', () => expectSaga().fn())
+            `,
+      filename: 'test.js',
+    },
+  ],
+  invalid: [
+    {
+      code: `
+            describe(() => {
+                it(() => {
+                    expectSaga()
+                })
+            })
+            `,
+      filename: 'test.js',
+      errors: [
         {
-            code: `
-      describe(() => {
-          it(() => {
-              expectSaga()
-          })
-      })
-      `,
-            filename: 'test.js',
-            errors: [
-                {
-                    message: 'expectSagas in `it` blocks should be returned',
-                },
-            ],
+          message: 'expectSagas in `it` blocks should be returned',
         },
-    ],
-});
+      ],
+    },
+    {
+      code: `
+              describe(() => {
+                  it(() => {
+                      doStuff()
+                      expectSaga()
+                  })
+              })
+              `,
+      filename: 'test.js',
+      errors: [
+        {
+          message: 'expectSagas in `it` blocks should be returned',
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
Add a rule to catch when `redux-saga-test-plan/expectSaga` is called incorrectly: 

Example of where tests will incorrectly pass, because `expectSaga()` isn't returned from the `it` block:
```
// Bad
it('works', () => {
  expectSaga(someSaga).silentRun()
})
```

How it actually needs to be written:
```
// Good
it('works', () => {
  return expectSaga(someSaga).silentRun()
})
```
Or
```
// Good
it('works', () => expectSaga(someSaga).silentRun())
```

`expectSaga()` returns a `Promise`, which jest will await if returned

This rule in action
![image](https://user-images.githubusercontent.com/38255501/66682399-01e10980-ec43-11e9-9910-aa287494f1ee.png)
