### PR TITLE
Make selector-naming-convention work with .ts & .tsx files

### DIFF
--- a/lib/rules/selector-naming-convention.js
+++ b/lib/rules/selector-naming-convention.js
@@ -48,5 +48,4 @@ module.exports = {
       })
     },
   }),
-  isSelectorFile,
 }

--- a/lib/rules/selector-naming-convention.js
+++ b/lib/rules/selector-naming-convention.js
@@ -12,9 +12,7 @@ const get = require('lodash/get')
 //------------------------------------------------------------------------------
 
 const isSelectorFile = (fileName = '') =>
-  fileName.endsWith('selectors.js') ||
-  fileName.endsWith('Selectors.js') ||
-  fileName.match(/selectors\/(.+).js/)
+  fileName.match(/selectors\/(.+).(js|tsx?)/)
 
 const isSelectorFunction = variableDeclarator =>
   get(variableDeclarator, 'init.type') === 'ArrowFunctionExpression' &&
@@ -50,4 +48,5 @@ module.exports = {
       })
     },
   }),
+  isSelectorFile,
 }

--- a/lib/rules/selector-naming-convention.js
+++ b/lib/rules/selector-naming-convention.js
@@ -10,9 +10,12 @@ const get = require('lodash/get')
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
-
+/*
+selectors/index.tsx
+selectors.js
+*/
 const isSelectorFile = (fileName = '') =>
-  fileName.match(/selectors\/(.+).(js|tsx?)/)
+  fileName.match(/selectors(\/)?(.*).(js|tsx?)/)
 
 const isSelectorFunction = variableDeclarator =>
   get(variableDeclarator, 'init.type') === 'ArrowFunctionExpression' &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-plugin-drop",
-  "version": "0.0.0",
+  "name": "@drop-engineering/eslint-plugin-drop",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/lib/rules/selector-naming-convention.js
+++ b/tests/lib/rules/selector-naming-convention.js
@@ -60,5 +60,23 @@ ruleTester.run('selector-naming-convention', rule, {
         },
       ],
     },
+    {
+      code: 'const stuff = state => state.stuff',
+      filename: 'selectors/index.ts',
+      errors: [
+        {
+          message: "Selector functions should be prefixed with 'get'",
+        },
+      ],
+    },
+    {
+      code: 'const stuff = state => state.stuff',
+      filename: 'selectors/index.tsx',
+      errors: [
+        {
+          message: "Selector functions should be prefixed with 'get'",
+        },
+      ],
+    },
   ],
 })

--- a/tests/lib/rules/selector-naming-convention.js
+++ b/tests/lib/rules/selector-naming-convention.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const rule = require('../../../lib/rules/selector-naming-convention')
+
 // eslint-disable-next-line
 const { RuleTester } = require('eslint')
 


### PR DESCRIPTION
Make lint rule that enforces that selectors should be prefixed with a `get` apply to .ts & .tsx files