### PR TITLE
Make typecheck rule more stable

### DIFF
--- a/lib/rules/typecheck.js
+++ b/lib/rules/typecheck.js
@@ -7,9 +7,30 @@
 
 const fs = require('fs')
 
+const { resolve } = require('path')
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
+
+/**
+ * Function that recursively walks up directories until it finds the root of the molly project
+ * Stops after reaching an arbitrary depth of 15
+ * The purpose of this function is to make this rule work regardless of how a file in molly was opened
+ * (eg: if a single file was opened using an editor, instead of the project root directory)
+ */
+const findMollyRoot = (startPath = process.cwd(), iterations = 1) => {
+  if (
+    fs.existsSync(`${startPath}/.typecheckignore`) &&
+    fs.existsSync(`${startPath}/package.json`)
+  ) {
+    return startPath
+  }
+  if (iterations <= 15) {
+    return findMollyRoot(`${startPath}/..`, iterations + 1)
+  }
+  throw new Error('Could not find molly root directory')
+}
 
 module.exports = {
   meta: {
@@ -24,8 +45,10 @@ module.exports = {
 
   create: context => {
     const { options } = context
-    const typecheckIgnorePath = options[0].typecheckignorePath
-    const pathsIgnored = fs
+    const mollyRoot = findMollyRoot()
+    const typecheckIgnorePath = `${mollyRoot}/.typecheckignore`
+
+    const filesInTypecheckignore = fs
       .readFileSync(typecheckIgnorePath, 'utf8')
       .split('\n')
       .filter(line => Boolean(line))
@@ -33,14 +56,16 @@ module.exports = {
 
     return {
       onCodePathStart: (codePath, node) => {
-        const currentFilename = context.getFilename()
-        const appliesToPaths = options[0].appliesToPaths
+        const currentFilename = resolve(context.getFilename())
+        const appliesToPaths = options[0].appliesToPaths.map(partialPath =>
+          resolve(`${mollyRoot}/${partialPath}`)
+        )
 
-        const currentFileApplies = appliesToPaths.some(path => {
+        const doesCurrentFileApply = appliesToPaths.some(path => {
           return currentFilename.startsWith(path)
         })
 
-        if (!currentFileApplies) {
+        if (!doesCurrentFileApply) {
           return
         }
 
@@ -52,17 +77,17 @@ module.exports = {
           return
         }
 
-        const isCurrentPathIgnored = pathsIgnored.some(ignoredPath => {
-          return currentFilename.includes(ignoredPath)
-        })
+        const isCurrentPathIgnored = filesInTypecheckignore.some(
+          ignoredPath => {
+            return currentFilename.includes(ignoredPath)
+          }
+        )
 
         if (isCurrentPathIgnored) {
           context.report({
             node,
-            message:
-              'Remove file from .typecheckignore to validate types in CI',
+            message: 'Remove file from .typecheckignore & fix typings',
           })
-          return
         }
       },
     }

--- a/lib/rules/typecheck.js
+++ b/lib/rules/typecheck.js
@@ -56,10 +56,14 @@ module.exports = {
 
     return {
       onCodePathStart: (codePath, node) => {
-        const currentFilename = resolve(context.getFilename())
-        const appliesToPaths = options[0].appliesToPaths.map(partialPath =>
-          resolve(`${mollyRoot}/${partialPath}`)
-        )
+        const currentFilename = fs.realpathSync(resolve(context.getFilename())) // Translates any symlinks to real paths
+
+        const appliesToPaths = options[0].appliesToPaths.map(partialPath => {
+          const realPath = fs.realpathSync(
+            resolve(`${mollyRoot}/${partialPath}`)
+          )
+          return realPath
+        })
 
         const doesCurrentFileApply = appliesToPaths.some(path => {
           return currentFilename.startsWith(path)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drop-engineering/eslint-plugin-drop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Drop javascript styleguide",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drop-engineering/eslint-plugin-drop",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Drop javascript styleguide",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Opening files in the project using an eslint enabled code editor would previously cause issues depending on how a file is opened. In particular, opening individual files using a text editor without first opening the `molly` root directory would break the rule, causing it to throw an error. 

This is now fixed, and the rule should work regardless of: 
- How a file within the project is opened
- Any symlinks being used by engineers (I have molly symlinked to `~/molly`) 


(See also https://sirupsen.com/shitlists/)