### PR TITLE
mapDispatchToProps rule

### DIFF
--- a/lib/rules/dispatch-actions.js
+++ b/lib/rules/dispatch-actions.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const get = require('lodash/get')
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Ensure actions are dispatched in mapDispatchToProps',
+      category: 'redux',
+      recommended: false,
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  create: context => {
+    return {
+      VariableDeclarator(node) {
+        if (get(node, 'id.name') !== 'mapDispatchToProps') return
+
+        if (!get(node, 'init.properties')) return
+
+        const boundFunctions = node.init.properties.filter(x => {
+          return get(x, 'value.type') === 'ArrowFunctionExpression'
+        })
+
+        if (!boundFunctions || !boundFunctions.length) return
+
+        const functionsWithMultipleExpresisons = boundFunctions.filter(x => {
+          return get(x, 'value.body.body.length') > 1
+        })
+
+        if (
+          !functionsWithMultipleExpresisons ||
+          !functionsWithMultipleExpresisons.length
+        )
+          return
+
+        const problemExpressions = functionsWithMultipleExpresisons.filter(
+          x => {
+            const body = get(x, 'value.body.body')
+            if (!body) return false
+
+            return x.value.body.body.some(x => {
+              return get(x, 'expression.type') === 'CallExpression'
+            })
+          }
+        )
+
+        if (problemExpressions.length)
+          context.report({
+            node,
+            message: 'Did you forget to dispatch actions?',
+          })
+      },
+    }
+  },
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drop-engineering/eslint-plugin-drop",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Drop javascript styleguide",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drop-engineering/eslint-plugin-drop",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Drop javascript styleguide",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/dispatch-actions.js
+++ b/tests/lib/rules/dispatch-actions.js
@@ -1,0 +1,65 @@
+'use strict'
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { resolve } = require('path')
+const { TSESLint } = require('@typescript-eslint/experimental-utils')
+const rule = require('../../../lib/rules/dispatch-actions')
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: resolve('./node_modules/@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+})
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+ruleTester.run('dispatch-actions', rule, {
+  valid: [
+    {
+      code: `
+      const mapDispatchToProps = {
+        action,
+      }
+      `,
+    },
+    {
+      code: `
+        const mapDispatchToProps = {
+          action: actionName,
+        }
+        `,
+    },
+    {
+      code: `
+          const mapDispatchToProps = {
+            action: () => actionName(),
+          }
+          `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: `
+      const mapDispatchToProps = {
+        action: () => {
+            action1()
+            action2()
+        },
+      }
+      `,
+      errors: [
+        {
+          message: 'Did you forget to dispatch actions?',
+        },
+      ],
+    },
+  ],
+})

--- a/tests/lib/rules/dispatch-actions.js
+++ b/tests/lib/rules/dispatch-actions.js
@@ -43,6 +43,13 @@ ruleTester.run('dispatch-actions', rule, {
           }
           `,
     },
+    {
+      code: `
+            const mapDispatchToProps = (dispatch) => ({
+              action: () => dispatch(actionName()),
+            })
+            `,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Rule to flag cases where we're not actually dispatching an action from `mapDispatchToProps`. Specifically designed to flag: 

```typescript

const mapDispatchToProps = {
    action: () => {
        action1()
        action2()
    },
}

```


See https://github.com/earnwithdrop/molly/pull/3413 for more info 