### PR TITLE
Improve useSelector rule

### DIFF
--- a/lib/rules/use-selector-and-use-dispatch.js
+++ b/lib/rules/use-selector-and-use-dispatch.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rules for useSelector
+ * @fileoverview Rules for useSelector & useDispatch
  * @author drop
  */
 
@@ -31,14 +31,14 @@ const isConnect = node =>
     get(node, 'callee.callee.name')
   )
 
-const USE_SELECTOR_ERROR_MESSAGE =
-  'Components using useSelector should be wrapped in React.memo(). See for [this link](https://blog.isquaredsoftware.com/2020/05/blogged-answers-a-mostly-complete-guide-to-react-rendering-behavior/#differences-between-connect-and-useselector) further reading.'
+const USE_SELECTOR_DISPATCH_ERROR_MESSAGE =
+  'Components using useSelector/useDispatch should be wrapped in React.memo(). Please see https://blog.isquaredsoftware.com/2020/05/blogged-answers-a-mostly-complete-guide-to-react-rendering-behavior/#differences-between-connect-and-useselector for more info.'
 
 module.exports = {
-  USE_SELECTOR_ERROR_MESSAGE,
+  USE_SELECTOR_DISPATCH_ERROR_MESSAGE: USE_SELECTOR_DISPATCH_ERROR_MESSAGE,
   meta: {
     docs: {
-      description: USE_SELECTOR_ERROR_MESSAGE,
+      description: USE_SELECTOR_DISPATCH_ERROR_MESSAGE,
       category: 'hooks',
       recommended: false,
     },
@@ -50,7 +50,8 @@ module.exports = {
     return {
       CallExpression(node) {
         const isUseSelector = node.callee.name === 'useSelector'
-        if (!isUseSelector) return
+        const isUseDispatch = node.callee.name === 'useDispatch'
+        if (!(isUseSelector || isUseDispatch)) return
 
         const isComponentWrappedInReactMemoInline = Boolean(
           recursivelyFindParentNode(node, node => isReactMemo(node))
@@ -105,7 +106,7 @@ module.exports = {
         context.report({
           node,
 
-          message: USE_SELECTOR_ERROR_MESSAGE,
+          message: USE_SELECTOR_DISPATCH_ERROR_MESSAGE,
         })
       },
     }

--- a/lib/rules/use-selector-and-use-dispatch.js
+++ b/lib/rules/use-selector-and-use-dispatch.js
@@ -35,7 +35,7 @@ const USE_SELECTOR_DISPATCH_ERROR_MESSAGE =
   'Components using useSelector/useDispatch should be wrapped in React.memo(). Please see https://blog.isquaredsoftware.com/2020/05/blogged-answers-a-mostly-complete-guide-to-react-rendering-behavior/#differences-between-connect-and-useselector for more info.'
 
 module.exports = {
-  USE_SELECTOR_DISPATCH_ERROR_MESSAGE: USE_SELECTOR_DISPATCH_ERROR_MESSAGE,
+  USE_SELECTOR_DISPATCH_ERROR_MESSAGE,
   meta: {
     docs: {
       description: USE_SELECTOR_DISPATCH_ERROR_MESSAGE,
@@ -61,7 +61,10 @@ module.exports = {
 
         const parentArrowFunction = recursivelyFindParentNode(node, node => {
           return (
-            get(node, 'init.type') === 'ArrowFunctionExpression' && node.id.name
+            (get(node, 'init.type') === 'ArrowFunctionExpression' ||
+              get(node, 'type') === 'FunctionDeclaration') &&
+            node.id.name &&
+            /^[A-Z]/.test(node.id.name)
           )
         })
 

--- a/lib/rules/use-selector-and-use-dispatch.js
+++ b/lib/rules/use-selector-and-use-dispatch.js
@@ -59,7 +59,7 @@ module.exports = {
 
         if (isComponentWrappedInReactMemoInline) return
 
-        const parentArrowFunction = recursivelyFindParentNode(node, node => {
+        const parentComponent = recursivelyFindParentNode(node, node => {
           return (
             (get(node, 'init.type') === 'ArrowFunctionExpression' ||
               get(node, 'type') === 'FunctionDeclaration') &&
@@ -68,14 +68,14 @@ module.exports = {
           )
         })
 
-        if (!parentArrowFunction) {
+        if (!parentComponent) {
           return
         }
 
-        const componentName = parentArrowFunction.id.name
+        const componentName = parentComponent.id.name
 
         const programNode = recursivelyFindParentNode(
-          parentArrowFunction,
+          parentComponent,
           x => x.type === 'Program'
         )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drop-engineering/eslint-plugin-drop",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Drop javascript styleguide",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drop-engineering/eslint-plugin-drop",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Drop javascript styleguide",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/use-selector-and-use-dispatch.js
+++ b/tests/lib/rules/use-selector-and-use-dispatch.js
@@ -89,6 +89,12 @@ const Component = () => {
 export default connect()(Component)
 `
 
+const VALID8 = `
+function useCustomHook() {
+  const x = HOOK_NAME
+}
+`
+
 const generateUseDispatchCode = input =>
   input.replace('HOOK_NAME', 'useDispatch()')
 const generateUseSelectorCode = input =>
@@ -102,6 +108,7 @@ const validCodeArray = [
   VALID5,
   VALID6,
   VALID7,
+  VALID8,
 ].reduce(
   (acc, curr) => [
     ...acc,

--- a/tests/lib/rules/use-selector-and-use-dispatch.js
+++ b/tests/lib/rules/use-selector-and-use-dispatch.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rules for useSelector
+ * @fileoverview Rules for useSelector & useDispatch
  * @author drop
  */
 
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 const { resolve } = require('path')
 const { TSESLint } = require('@typescript-eslint/experimental-utils')
-const rule = require('../../../lib/rules/use-selector-rules')
+const rule = require('../../../lib/rules/use-selector-and-use-dispatch')
 
 const ruleTester = new TSESLint.RuleTester({
   parser: resolve('./node_modules/@typescript-eslint/parser'),
@@ -34,28 +34,28 @@ const Component = () => {
 `
 const INVALID1 = `
 const Component = () => {
-  const selectorValue = useSelector(selector)
+  const selectorValue = HOOK_NAME
   return <View />
 }
 `
 
 const VALID2 = `
 const Component = React.memo(() => {
-  const selectorValue = useSelector(selector)
+  const selectorValue = HOOK_NAME
   return <View />
 })
 `
 
 const VALID3 = `
 const Component = React.memo((props: {x: number}) => {
-  const selectorValue = useSelector(selector)
+  const selectorValue = HOOK_NAME
   return <View />
 })
 `
 
 const VALID4 = `
 const Component = () => {
-  const selectorValue = useSelector(selector)
+  const selectorValue = HOOK_NAME
   return <View />
 }
 
@@ -64,7 +64,7 @@ export const MemoizedComponent = React.memo(Component)
 
 const VALID5 = `
 const Component = () => {
-  const selectorValue = useSelector(selector)
+  const selectorValue = HOOK_NAME
   return <View />
 }
 
@@ -73,7 +73,7 @@ export default React.memo(Component)
 
 const VALID6 = `
 const Component = () => {
-  const selectorValue = useSelector(selector)
+  const selectorValue = HOOK_NAME
   return <View />
 }
 
@@ -82,46 +82,52 @@ export const ConnectedComponent = connect()(Component)
 
 const VALID7 = `
 const Component = () => {
-  const selectorValue = useSelector(selector)
+  const selectorValue = HOOK_NAME
   return <View />
 }
 
 export default connect()(Component)
 `
 
-ruleTester.run('use-selector-rules', rule, {
-  valid: [
-    {
-      code: VALID1,
-    },
-    {
-      code: VALID2,
-    },
-    {
-      code: VALID3,
-    },
-    {
-      code: VALID4,
-    },
-    {
-      code: VALID5,
-    },
-    {
-      code: VALID6,
-    },
-    {
-      code: VALID7,
-    },
-  ],
+const generateUseDispatchCode = input =>
+  input.replace('HOOK_NAME', 'useDispatch()')
+const generateUseSelectorCode = input =>
+  input.replace('HOOK_NAME', 'useSelector(selector)')
 
-  invalid: [
+const validCodeArray = [
+  VALID1,
+  VALID2,
+  VALID3,
+  VALID4,
+  VALID5,
+  VALID6,
+  VALID7,
+].reduce(
+  (acc, curr) => [
+    ...acc,
+    { code: generateUseDispatchCode(curr) },
+    { code: generateUseSelectorCode(curr) },
+  ],
+  []
+)
+
+const invalidCodeArray = [INVALID1].reduce(
+  (acc, curr) => [
+    ...acc,
     {
-      code: INVALID1,
-      errors: [
-        {
-          message: rule.USE_SELECTOR_ERROR_MESSAGE,
-        },
-      ],
+      code: generateUseDispatchCode(curr),
+      errors: [{ message: rule.USE_SELECTOR_DISPATCH_ERROR_MESSAGE }],
+    },
+    {
+      code: generateUseSelectorCode(curr),
+      errors: [{ message: rule.USE_SELECTOR_DISPATCH_ERROR_MESSAGE }],
     },
   ],
+  []
+)
+
+ruleTester.run('use-selector-rules', rule, {
+  valid: validCodeArray,
+
+  invalid: invalidCodeArray,
 })


### PR DESCRIPTION
- The rule now also flags usage of `useDispatch` when the component is not wrapped in a `useMemo`
- Custom hooks that use either `useSelector` or `useDispatch` are no longer incorrectly flagged
- The rule now also supports components defined as plain old functions and not just arrow functions like before